### PR TITLE
PHP 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-alpine
+FROM php:8.0-alpine
 
 RUN curl -o /usr/local/bin/composer https://getcomposer.org/composer.phar \
     && chmod +x /usr/local/bin/composer

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Tests can be run with:
 composer test
 ```
 
+### Static Code analyse
+
+Code can be static analysed with [PHPStan](https://phpstan.org/):
+```bash
+composer analyse
+```
+
 ### Continue building
 
 Go ahead and:

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
   ],
   "require": {
     "php": "^8.0",
-    "symfony/config": "^5.4",
-    "symfony/console": "^5.4",
-    "symfony/dependency-injection": "^5.4",
-    "symfony/yaml": "^5.4"
+    "symfony/config": "^6.0",
+    "symfony/console": "^6.0",
+    "symfony/dependency-injection": "^6.0",
+    "symfony/yaml": "^6.0"
   },
   "require-dev": {
-    "clue/phar-composer": "dev-master",
-    "phpstan/phpstan": "^1.2",
+    "clue/phar-composer": "^1.3",
+    "phpstan/phpstan": "^1.4",
     "phpunit/phpunit": "^9.5",
-    "symfony/var-dumper": "^5.4"
+    "symfony/var-dumper": "^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     }
   ],
   "require": {
-    "php": "^7.2",
-    "symfony/config": "^5.0",
-    "symfony/console": "^5.0",
-    "symfony/dependency-injection": "^5.0",
-    "symfony/yaml": "^5.0"
+    "php": "^8.0",
+    "symfony/config": "^5.4",
+    "symfony/console": "^5.4",
+    "symfony/dependency-injection": "^5.4",
+    "symfony/yaml": "^5.4"
   },
   "require-dev": {
-    "clue/phar-composer": "^1.1",
-    "phpunit/phpunit": "^8.2",
-    "symfony/var-dumper": "^5.0"
+    "clue/phar-composer": "dev-master",
+    "phpunit/phpunit": "^9.5",
+    "symfony/var-dumper": "^5.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
   },
   "require-dev": {
     "clue/phar-composer": "dev-master",
+    "phpstan/phpstan": "^1.2",
     "phpunit/phpunit": "^9.5",
     "symfony/var-dumper": "^5.4"
   },
@@ -35,7 +36,8 @@
   "bin": ["./app"],
   "scripts": {
     "test": "./vendor/bin/phpunit",
-    "build": "./vendor/bin/phar-composer build"
+    "build": "./vendor/bin/phar-composer build",
+    "analyse": "./vendor/bin/phpstan analyse"
   },
   "config": {
     "sort-packages": true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 9
+	paths:
+		- src

--- a/src/Command/ExampleCommand.php
+++ b/src/Command/ExampleCommand.php
@@ -16,16 +16,16 @@ class ExampleCommand extends Command
         // TODO: inject and initialize any services needed for the command here
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('example')
             ->setDescription('Example command');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('This is an example, replace or edit me');
 
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
- Require PHP ^8.0
- Update Symfony components to ^6.0
- PHPUnit 9.5
- Add PHPStan to skeleton (with configured level 9)
- [clue/phar-composer 1.3](https://github.com/clue/phar-composer/releases/tag/v1.3.0), with support for PHP 8.1